### PR TITLE
some changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Each topic includes a set of questions to help you prepare for your interview. W
 
 10.[What are references in C++?](./c.md/10.md)
 
-
+11.[How is the assignment operator ( = ) different from the equal to operator ( == )?](./c.md/11.md)
 
 ### Coding Interview Questions
 

--- a/c.md/11.md
+++ b/c.md/11.md
@@ -1,0 +1,26 @@
+# How is the assignment operator ( = ) different from the equal to operator ( == )?
+
+The assignment operator ( = ) and the equal to operator ( == ) are two different operators used in programming. The key difference between them is their purpose and how they behave.
+
+The assignment operator ( = ) is used to assign a value to a variable. For example:
+makefile
+x = 5;
+
+This statement assigns the value 5 to the variable x.
+
+On the other hand, the equal to operator ( == ) is used to compare two values and returns a boolean value (true or false) indicating whether they are equal or not. For example:
+makefile
+x = 5;
+
+This statement compares the value of x with the value 5 and returns true if they are equal, and false otherwise.
+
+One common mistake that programmers make is to use the assignment operator ( = ) when they mean to use the equal to operator ( == ). For example:
+perl
+if (x = 5) {
+    // do something
+}
+
+This statement assigns the value 5 to the variable x and then checks whether the value of x is true (which it is, because non-zero values are considered true). This may not be what the programmer intended, and can lead to unexpected results.
+
+To avoid this mistake, it is recommended to always use the equal to operator ( == ) when comparing values in conditional statements.
+


### PR DESCRIPTION
# How is the assignment operator ( = ) different from the equal to operator ( == )?

The assignment operator ( = ) and the equal to operator ( == ) are two different operators used in programming. The key difference between them is their purpose and how they behave.

The assignment operator ( = ) is used to assign a value to a variable. For example:
makefile
x = 5;

This statement assigns the value 5 to the variable x.

On the other hand, the equal to operator ( == ) is used to compare two values and returns a boolean value (true or false) indicating whether they are equal or not. For example:
makefile
x = 5;

This statement compares the value of x with the value 5 and returns true if they are equal, and false otherwise.

One common mistake that programmers make is to use the assignment operator ( = ) when they mean to use the equal to operator ( == ). For example:
perl
if (x = 5) {
    // do something
}

This statement assigns the value 5 to the variable x and then checks whether the value of x is true (which it is, because non-zero values are considered true). This may not be what the programmer intended, and can lead to unexpected results.

To avoid this mistake, it is recommended to always use the equal to operator ( == ) when comparing values in conditional statements.

